### PR TITLE
added fix for kernel 6.0.0, but after that other errors appeared rela…

### DIFF
--- a/ap.c
+++ b/ap.c
@@ -358,7 +358,12 @@ static int xradio_set_btcoexinfo(struct xradio_vif *priv)
 void xradio_bss_info_changed(struct ieee80211_hw *dev,
 			     struct ieee80211_vif *vif,
 			     struct ieee80211_bss_conf *info,
-			     u32 changed)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+			     u64 changed
+#else
+			     u32 changed
+#endif
+			     )
 {
 	struct xradio_common *hw_priv = dev->priv;
 	struct xradio_vif *priv = xrwl_get_vif_from_ieee80211(vif);

--- a/ap.h
+++ b/ap.h
@@ -9,6 +9,8 @@
  * published by the Free Software Foundation.
  */
 
+#include <linux/version.h>
+
 #ifndef AP_H_INCLUDED
 #define AP_H_INCLUDED
 
@@ -32,7 +34,12 @@ void xradio_sta_notify(struct ieee80211_hw *dev, struct ieee80211_vif *vif,
 void xradio_bss_info_changed(struct ieee80211_hw *dev,
 			     struct ieee80211_vif *vif,
 			     struct ieee80211_bss_conf *info,
-			     u32 changed);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+			     u64 changed
+#else
+			     u32 changed
+#endif
+			     );
 int xradio_ampdu_action(struct ieee80211_hw *hw,
 			struct ieee80211_vif *vif,
 			struct ieee80211_ampdu_params *params);

--- a/sta.c
+++ b/sta.c
@@ -704,6 +704,9 @@ void xradio_configure_filter(struct ieee80211_hw *hw,
 }
 
 int xradio_conf_tx(struct ieee80211_hw *dev, struct ieee80211_vif *vif,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+                  unsigned int link_id,
+#endif
                    u16 queue, const struct ieee80211_tx_queue_params *params)
 {
 	struct xradio_common *hw_priv = dev->priv;

--- a/sta.h
+++ b/sta.h
@@ -51,7 +51,11 @@ void xradio_configure_filter(struct ieee80211_hw *dev,
                              unsigned int *total_flags,
                              u64 multicast);
 int xradio_conf_tx(struct ieee80211_hw *dev, struct ieee80211_vif *vif,
-                   u16 queue, const struct ieee80211_tx_queue_params *params);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+                   unsigned int link_id,
+#endif
+                   u16 queue,
+                   const struct ieee80211_tx_queue_params *params);
 int xradio_get_stats(struct ieee80211_hw *dev,
                      struct ieee80211_low_level_stats *stats);
 /* Not more a part of interface?


### PR DESCRIPTION
…ted to changes in mac80211.h

  CC [M]  drivers/net/wireless/rtl8189fs/hal/phydm/phydm_soml.o
drivers/net/wireless/xradio/main.c:152:30: error: initialization of ‘void (*)(struct ieee80211_hw *, struct ieee80211_vif *, struct ieee80211_bss_conf *, u64)’ {aka ‘void (*)(struct ieee80211_hw *, struct ieee80211_vif *, struct ieee80211_bss_conf *, long long unsigned int)’} from incompatible pointer type ‘void (*)(struct ieee80211_hw *, struct ieee80211_vif *, struct ieee80211_bss_conf *, u32)’ {aka ‘void (*)(struct ieee80211_hw *, struct ieee80211_vif *, struct ieee80211_bss_conf *, unsigned int)’} [-Werror=incompatible-pointer-types]
  152 |         .bss_info_changed  = xradio_bss_info_changed,
      |                              ^~~~~~~~~~~~~~~~~~~~~~~
drivers/net/wireless/xradio/main.c:152:30: note: (near initialization for ‘xradio_ops.bss_info_changed’)
drivers/net/wireless/xradio/main.c:155:30: error: initialization of ‘int (*)(struct ieee80211_hw *, struct ieee80211_vif *, unsigned int,  u16,  const struct ieee80211_tx_queue_params *)’ {aka ‘int (*)(struct ieee80211_hw *, struct ieee80211_vif *, unsigned int,  short unsigned int,  const struct ieee80211_tx_queue_params *)’} from incompatible pointer type ‘int (*)(struct ieee80211_hw *, struct ieee80211_vif *, u16,  const struct ieee80211_tx_queue_params *)’ {aka ‘int (*)(struct ieee80211_hw *, struct ieee80211_vif *, short unsigned int,  const struct ieee80211_tx_queue_params *)’} [-Werror=incompatible-pointer-types]
  155 |         .conf_tx           = xradio_conf_tx,
      |                              ^~~~~~~~~~~~~~
drivers/net/wireless/xradio/main.c:155:30: note: (near initialization for ‘xradio_ops.conf_tx’)
cc1: some warnings being treated as errors
make[4]: *** [scripts/Makefile.build:249: drivers/net/wireless/xradio/main.o] Error 1
make[3]: *** [scripts/Makefile.build:465: drivers/net/wireless/xradio] Error 2
make[3]: *** Waiting for unfinished jobs....